### PR TITLE
Fix nosimple args typo

### DIFF
--- a/yarGen.py
+++ b/yarGen.py
@@ -266,7 +266,7 @@ def malwareStringEvaluation(mal_string_stats, good_strings):
                     # If the string set of the combination has a required size
                     if len(combinations[combi]["strings"]) >= int(args.rc):
                         # Remove the files in the combi rule from the simple set
-                        if args.nosingle:
+                        if args.nosimple:
                             for file in combinations[combi]["files"]:
                                 if file in file_strings:
                                     del file_strings[file]


### PR DESCRIPTION
Fixed exception

Traceback (most recent call last):
  File "yarGen.py", line 1056, in <module>
    (file_strings, combinations, super_rules) = malwareStringEvaluation(mal_string_stats, good_strings)
  File "yarGen.py", line 269, in malwareStringEvaluation
    if args.nosinple:
AttributeError: 'Namespace' object has no attribute 'nosinple'
