### PR TITLE
allow the script to be executed from any directory

### DIFF
--- a/yarGen.py
+++ b/yarGen.py
@@ -639,7 +639,7 @@ def filter_string_set(string_set):
                 localStringScores[string] += 5
             # Missed user profiles
             if re.search(r'[\\](users|profiles|username|benutzer|Documents and Settings|Utilisateurs|Utenti|'
-                         r'Usu·rios)[\\]', string, re.IGNORECASE):
+                         r'Usu√°rios)[\\]', string, re.IGNORECASE):
                 localStringScores[string] += 3
             # Strings: Words ending with numbers
             if re.search(r'^[A-Z][a-z]+[0-9]+$', string, re.IGNORECASE):
@@ -1884,7 +1884,7 @@ if __name__ == '__main__':
         strings_num = 0
 
         # Initialize all databases
-        for file in os.listdir("./dbs/"):
+        for file in os.listdir(get_abs_path("./dbs/")):
             if not file.endswith(".db"):
                 continue
             filePath = os.path.join("./dbs/", file)


### PR DESCRIPTION
Currently, executing the script from the parent directory will throw an error:
```
File "yara/yarGen-master/yarGen.py", line 1887, in
for file in os.listdir("./dbs/"):
OSError: [Errno 2] No such file or directory: './dbs/
```

This patch fix the issue.

Also, line 642 was automatically changed by github online editor. So that the file is UTF-8 instead of ISO-8859-1.