### PR TITLE
Use cwd for getting the absolute path

### DIFF
--- a/yarGen.py
+++ b/yarGen.py
@@ -84,7 +84,7 @@ KNOWN_IMPHASHES = {'a04dd9f5ee88d7774203e0a0cfa1b941': 'PsExec',
 
 
 def get_abs_path(filename):
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+    return os.path.join(os.getcwd(), filename)
 
 
 def get_files(dir, notRecursive):


### PR DESCRIPTION
Sometimes, directories adjacent to yarGen.py are unwritable (e.g. in the case of
being installed to the Nix store). Instead, read from the current directory.