### PR TITLE
Fix typo in help

### DIFF
--- a/yarGen.py
+++ b/yarGen.py
@@ -2106,7 +2106,7 @@ if __name__ == '__main__':
 
     group_general = parser.add_argument_group('General Options')
     group_general.add_argument('--dropzone', action='store_true', default=False,
-                               help='Dropzone mode - monitors a directory [-m] for new samples to process'
+                               help='Dropzone mode - monitors a directory [-m] for new samples to process. '
                                     'WARNING: Processed files will be deleted!')
     group_general.add_argument('--nr', action='store_true', default=False, help='Do not recursively scan directories')
     group_general.add_argument('--oe', action='store_true', default=False, help='Only scan executable extensions EXE, '


### PR DESCRIPTION
There is a typo in the help, resulting in there being no space between the "process" and "WARNING" in "Dropzone mode - monitors a directory [-m] for new samples to processWARNING: Processed files will be deleted!":
![image](https://user-images.githubusercontent.com/84232764/234692133-9ee11b0b-8f38-43a3-a77a-71b820c05fee.png)
This PR adds a period and a space to the previous sentence to hopefully avoid this.
Thank you.