### PR TITLE
source path of identifier should always be path of malware samples

### DIFF
--- a/yarGen.py
+++ b/yarGen.py
@@ -2181,8 +2181,6 @@ Recommended command line:
 
     # Identifier
     sourcepath = args.m
-    if args.g:
-        sourcepath = args.g
     identifier = getIdentifier(args.b, sourcepath)
     print("[+] Using identifier '%s'" % identifier)
 


### PR DESCRIPTION
Delete the lines that make the identifier of the output yara file named the path of goodware (`args.g`); it should always be based on the path of malwarew (`args.m`)