### PR TITLE
bugfix for PE identification by MZ & replace `pefile` with `lief` to support opcode extraction for ELF file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pefile
+lief
 lxml

--- a/yarGen.py
+++ b/yarGen.py
@@ -377,7 +377,7 @@ def extract_opcodes(fileData):
     return opcodes
 
 
-def get_pe_info(fileData):
+def get_pe_info(fileData: bytes):
     """
     Get different PE attributes and hashes
     :param fileData:
@@ -386,7 +386,7 @@ def get_pe_info(fileData):
     imphash = ""
     exports = []
     # Check for MZ header (speed improvement)
-    if fileData[:2] != "MZ":
+    if fileData[:2] != b"MZ":
         return imphash, exports
     try:
         if args.debug:


### PR DESCRIPTION
Hi, it seems that I found a bug.
The type of fileData is `bytes`, and `bytes` cannot be directly compared with `str` in Python 3.x (which will always lead to False).

Just fixed it.