### PR TITLE
bugfix for misuse of `bytes` and `str` & refinement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,17 @@
+# IDE & Virtual Environment
 .idea/
 venv/
-samples/
-dbs/
-# General
+
+# MacOS
 .DS_Store
 .AppleDouble
 .LSOverride
 
 # Thumbnails
 ._*
+
+# Prebuilt Database
+dbs/
 
 # YARA Rules
 yargen_rules.yar

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.idea/
+venv/
+samples/
+dbs/
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# YARA Rules
+yargen_rules.yar


### PR DESCRIPTION
Hi,
I found a few more bugs during use. Some of them are caused by misuse of `bytes` and `str` (e.g., to check if a `bytes` is in a Counter whose keys are `str`, which will always lead to `False`).
There are also some trivial yet fatal problems like `dict.keys()[0]` or `dict.items()[0]`, which is illegal in Python 3.x (it should be `list(dict.keys())[0]`).

Btw, It looks that all problems are caused by code migration from Python 2 to 3.

Have fixed them and refined the code.