### PR TITLE
Decouple the condition for using opcode from imphash and exported symbols

### DIFF
--- a/yarGen.py
+++ b/yarGen.py
@@ -2390,7 +2390,6 @@ Recommended command line:
         if len(good_exports_db) < 1 and len(good_imphashes_db) < 1:
             print("[E] Missing goodware imphash/export databases. "
                   "    Please run 'yarGen.py --update' to retrieve the newest database set.")
-            use_opcodes = False
 
         if len(good_strings_db) < 1 and not args.c:
             print("[E] Error - no goodware databases found. "


### PR DESCRIPTION
Hi,

According to the original code, if there is no exported symbols and imphashes from goodware db, the program will never use opcode. This logic confuses me since I do not know why the application of opcode has an strong association with imphash and exported symbols. IMO, even if there are no exported symbols and imphashes (implying the goodware samples are self-contained and they do not import/expose anything from/to external), we can still use opcode feature for identification because it is virtually able to extract opcodes from them. So I change the logic, and it works well on my dataset.