### PR TITLE
Bugfix for PE identification & produce condition in illegal syntax for super rules under certain args

### DIFF
--- a/yarGen.py
+++ b/yarGen.py
@@ -1190,7 +1190,7 @@ def generate_rules(file_strings, file_opcodes, super_rules, file_info, inverse_s
                 condition_pe = []
                 condition_pe_part1 = []
                 condition_pe_part2 = []
-                if not args.noextras and file_info[filePath]["magic"] == "MZ":
+                if not args.noextras and file_info[filePath]["magic"] == binascii.hexlify(b"MZ").decode('ascii'):
                     # Add imphash - if certain conditions are met
                     if file_info[filePath]["imphash"] not in good_imphashes_db and file_info[filePath]["imphash"] != "":
                         # Comment to imphash

--- a/yarGen.py
+++ b/yarGen.py
@@ -1423,7 +1423,8 @@ def generate_rules(file_strings, file_opcodes, super_rules, file_info, inverse_s
                     cond_op = " and all of ($op*)"
 
                 condition2 = "( {0} ){1}".format(cond_combined, cond_op)
-                conditions.append(" and ".join([condition_strings, condition2]))
+                # condition_strings could be ""
+                conditions.append(" and ".join(filter(lambda x: x != "", [condition_strings, condition2])))
 
                 # 3nd condition
                 # In memory detection base condition (no magic, no filesize)


### PR DESCRIPTION
Bugfix for PE identification & produce condition in illegal syntax for super rules under certain args (--nofilesize --nomagic --noextras)